### PR TITLE
workflows: fix typo from migration

### DIFF
--- a/.github/workflows/cron-sync-lts.yaml
+++ b/.github/workflows/cron-sync-lts.yaml
@@ -19,8 +19,8 @@ jobs:
 
       - id: get-fb-release
         run: |
-          curl -sSfl -H "Authorization: Bearer $GITHUB_TOKEN"  https://api.github.com/repos/chronosphereio/calyptia-calyptia-fluent-bit/releases/latest
-          LATEST_RELEASE_TAG=$(curl -sSfl -H "Authorization: Bearer $GITHUB_TOKEN"  https://api.github.com/repos/chronosphereio/calyptia-calyptia-fluent-bit/releases/latest|jq -r .tag_name)
+          curl -sSfl -H "Authorization: Bearer $GITHUB_TOKEN"  https://api.github.com/repos/chronosphereio/calyptia-fluent-bit/releases/latest
+          LATEST_RELEASE_TAG=$(curl -sSfl -H "Authorization: Bearer $GITHUB_TOKEN"  https://api.github.com/repos/chronosphereio/calyptia-fluent-bit/releases/latest|jq -r .tag_name)
           echo "Found tag for latest release: $LATEST_RELEASE_TAG"
           echo "tag=$LATEST_RELEASE_TAG" >> $GITHUB_OUTPUT
         shell: bash


### PR DESCRIPTION
Fix incorrect name of repo, resolves https://github.com/chronosphereio/calyptia-charts/actions/runs/8118230675/job/22192092523