### PR TITLE
update: core-crd fluent-bit image to 24.4.2.

### DIFF
--- a/charts/core-crd/values.yaml
+++ b/charts/core-crd/values.yaml
@@ -7,7 +7,7 @@ images:
   fluentBit:
     registry: ghcr.io
     repository: calyptia/core/calyptia-fluent-bit
-    tag: 23.10.2
+    tag: 24.4.2
     pullSecrets: []
   ingestCheck:
     registry: ghcr.io


### PR DESCRIPTION
Update the fluent-bit image to 24.4.2 to match the default in core-operator.