### PR TITLE
Revert "ci: update Core Operator chart from latest version internally (#285)"

### DIFF
--- a/charts/core-crd/Chart.yaml
+++ b/charts/core-crd/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: core-crd
 description: A Helm chart for Kubernetes
 type: application
-version: 3.12.0
-appVersion: "v3.12.0"
+version: 3.8.0
+appVersion: "v3.8.0"
 maintainers:
   - name: Calyptia
     email: hello@calyptia.com

--- a/charts/core-crd/templates/pipelines.yaml
+++ b/charts/core-crd/templates/pipelines.yaml
@@ -788,10 +788,6 @@ spec:
                 kind:
                   description: Enums
                   type: string
-                labels:
-                  additionalProperties:
-                    type: string
-                  type: object
                 ports:
                   items:
                     properties:
@@ -848,9 +844,6 @@ spec:
                           type: object
                       type: object
                   type: object
-                serviceAccount:
-                  description: service account for pipelines
-                  type: string
                 tolerations:
                   items:
                     description: |-

--- a/charts/core-crd/values.yaml
+++ b/charts/core-crd/values.yaml
@@ -9,7 +9,7 @@ images:
   fluentBit:
     registry: ghcr.io
     repository: calyptia/core/calyptia-fluent-bit
-    tag: 24.11.2
+    tag: 24.11.1
     pullSecrets: []
   ingestCheck:
     registry: ghcr.io

--- a/charts/core-instance/Chart.yaml
+++ b/charts/core-instance/Chart.yaml
@@ -4,8 +4,8 @@ description: Calyptia Core Instance chart
 home: https://calyptia.com/products/core/
 icon: https://storage.googleapis.com/calyptia_public_resources_bucket/logo-darkmode.svg
 type: application
-version: 3.12.0
-appVersion: "v3.12.0"
+version: 3.8.0
+appVersion: "v3.8.0"
 maintainers:
   - name: Calyptia
     email: hello@calyptia.com

--- a/charts/core-instance/values.yaml
+++ b/charts/core-instance/values.yaml
@@ -22,12 +22,12 @@ images:
   fromCloud:
     registry: ghcr.io
     repository: calyptia/core-operator/sync-from-cloud
-    tag: 3.12.0
+    tag: 3.8.0
     pullSecrets: []
   toCloud:
     registry: ghcr.io
     repository: calyptia/core-operator/sync-to-cloud
-    tag: 3.12.0
+    tag: 3.8.0
     pullSecrets: []
   hotReload:
     registry: ghcr.io

--- a/charts/core-operator/Chart.yaml
+++ b/charts/core-operator/Chart.yaml
@@ -4,8 +4,8 @@ description: Calyptia Core Operator chart
 home: https://calyptia.com/products/core/
 icon: https://storage.googleapis.com/calyptia_public_resources_bucket/logo-darkmode.svg
 type: application
-version: 3.12.0
-appVersion: "v3.12.0"
+version: 3.8.0
+appVersion: "v3.8.0"
 maintainers:
   - name: Calyptia
     email: hello@calyptia.com

--- a/charts/core-operator/templates/manager.yaml
+++ b/charts/core-operator/templates/manager.yaml
@@ -55,9 +55,6 @@ spec:
           {{- if .Values.livenessProbe }}
           livenessProbe: {{- toYaml .Values.livenessProbe | nindent 12 }}
           {{- end }}
-          env:
-            - name: POD_SERVICEACCOUNT
-              value: calyptia-core-po-sa
           name: manager
           ports:
             - containerPort: 8443

--- a/charts/core-operator/templates/rolebinding.yaml
+++ b/charts/core-operator/templates/rolebinding.yaml
@@ -41,28 +41,5 @@ subjects:
 - kind: ServiceAccount
   name: {{ template "operator.serviceAccountName" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  labels:
-    app.kubernetes.io/created-by: core-operator
-    app.kubernetes.io/managed-by: core-operator
-    app.kubernetes.io/part-of: calyptia
-    calyptia.core: core-operator
-  name: calyptia-core-pod-rolebinding
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: calyptia-core-pod-role
-subjects:
-- kind: ServiceAccount
-  name: calyptia-core-po-sa
-  namespace: {{ .Release.Namespace }}
-{{- range .Values.serviceAccounts }}
-- kind: ServiceAccount
-  name: {{ .name | quote }}
-  namespace: {{ .namespace | quote }}
-  {{- end }}
 {{- end -}}
 {{- end }}

--- a/charts/core-operator/templates/service-account.yaml
+++ b/charts/core-operator/templates/service-account.yaml
@@ -14,21 +14,5 @@ metadata:
     calyptia.core: core-operator
   name: {{ template "operator.serviceAccountName" . }}
   namespace: {{ include "common.names.namespace" . | quote }}
----
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  {{- $mergedAnnotations := merge .Values.serviceAccount.annotations .Values.commonAnnotations }}
-  {{- if $mergedAnnotations }}
-  annotations: {{- include "common.tplvalues.render" ( dict "value" $mergedAnnotations "context" $ ) | nindent 4 }}
-  {{- end }}
-  labels: {{- include "common.labels.standard" . | nindent 4 }}
-    app.kubernetes.io/component: rbac
-    app.kubernetes.io/created-by: operator
-    app.kubernetes.io/part-of: operator
-    calyptia.core: core-operator
-  name: calyptia-core-po-sa
-  namespace: {{ include "common.names.namespace" . | quote }}
 {{- end }}
 {{- end }}

--- a/charts/core-operator/tests/manager_test.yaml
+++ b/charts/core-operator/tests/manager_test.yaml
@@ -87,11 +87,3 @@ tests:
       - equal:
           path: spec.template.spec.tolerations[0].operator
           value: "Exists"
-  - it: checks env var
-    asserts:
-      - equal:
-          path: spec.template.spec.containers[0].env[0]
-          value:
-            name: POD_SERVICEACCOUNT
-            value: calyptia-core-po-sa
-

--- a/charts/core-operator/values.yaml
+++ b/charts/core-operator/values.yaml
@@ -4,7 +4,7 @@ images:
   operator:
     registry: ghcr.io
     repository: calyptia/core-operator
-    tag: 3.12.0
+    tag: 3.8.0
     pullSecrets: []
   hotReload:
     registry: ghcr.io
@@ -78,7 +78,3 @@ livenessProbe:
   initialDelaySeconds: 15
   periodSeconds: 20
 restartPolicy: Always
-serviceAccounts: []
-# - name: exampleSA
-#   namespace: exampleNamespace
-podServiceAccount: calyptia-core-po-sa


### PR DESCRIPTION
This reverts commit 8807ad34469dee9f06012a20352ea51ced6cd6e1.