### PR TITLE
fix: improve the support.sh script. Secrets are now redacted.

### DIFF
--- a/support.sh
+++ b/support.sh
@@ -53,6 +53,12 @@ do
         \kubectl get -n "$namespace" "$resource_type" --show-kind --ignore-not-found -o yaml > "${OUTPUT_DIR}/namespaces/${namespace}"/"$resource_type".yaml
     done
 
+    # Get secrets in the namespace. All data values will be redacted.
+    for secret in $(\kubectl get secrets -n "$namespace" -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
+    do
+        \kubectl get secret "$secret" -n "$namespace" -o json | jq '.data |= with_entries(.value = "--REDACTED--")' >> "${OUTPUT_DIR}/namespaces/${namespace}"/secrets.json
+    done
+
     # Attempt to discover token and url for cloud-api in cluster
     if [[ -z "$CALYPTIA_CLOUD_TOKEN" ]]; then
         if \kubectl get --namespace "$namespace" secret auth-secret &>/dev/null; then

--- a/support.sh
+++ b/support.sh
@@ -46,8 +46,8 @@ mkdir -p "$OUTPUT_DIR"/cluster
 # Grab stuff not returned by `get all`
 for namespace in $(\kubectl get namespaces --output=jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}')
 do
-    # Get YAML for everything in the namespace
-    for resource_type in $(\kubectl api-resources --namespaced --verbs=list -o name | tr "\n" " ");
+    # Get YAML for everything in the namespace, except secrets. If more resources need to be excluded, add them to the grep list.
+    for resource_type in $(\kubectl api-resources --namespaced --verbs=list -o name | grep -Ewv "^(secrets)$" | tr "\n" " ");
     do
         mkdir -p "${OUTPUT_DIR}/namespaces/${namespace}"
         \kubectl get -n "$namespace" "$resource_type" --show-kind --ignore-not-found -o yaml > "${OUTPUT_DIR}/namespaces/${namespace}"/"$resource_type".yaml


### PR DESCRIPTION
Removed the secrets from the resources discovery.

Then get the secrets from the corresponding namespace.
All values for the keys inside .data will be redacted.
Getting the list of secrets and the metadata could be useful for troubleshooting, hence keeping them.