### PR TITLE
[sc-143764] Upgrade configmap-reload and ingest-check images for CVE

### DIFF
--- a/charts/core-instance/values.yaml
+++ b/charts/core-instance/values.yaml
@@ -59,14 +59,14 @@ images:
     ## @param images.hotReload.repository Image repository.
     repository: calyptia/configmap-reload
     ## @param images.hotReload.tag Image tag.
-    tag: 0.11.1
+    tag: 0.15.0
   ingestCheck:
     ## @param images.ingestCheck.registry Image registry. This can be overridden by `global.imageRegistry`.
     registry: ghcr.io
     ## @param images.ingestCheck.repository Image repository.
     repository: calyptia/core/ingest-check
     ## @param images.ingestCheck.tag Image tag.
-    tag: 0.0.7
+    tag: 1.0.1
 ## @param interval How often to sync data to/from the cloud.
 interval: "15s"
 ## @param probeIntervalSec How often to run liveness and readiness probes. If 0, probes are disabled.


### PR DESCRIPTION
The versions of Go used by the versions of the ingest-check and
configmap-reload images had critical CVEs. To mitigate, we simply
need to upgrade to newer versions of both which are also using
newer versions of Go. The [shortcut](https://app.shortcut.com/chronosphere/story/143764/critical-cve-ingest-check-and-configmap-reload) story has more details on the
particulars of the CVE.

More interestingly, even though we have a calyptia/configmap-reload
package in our github _package_ repository, there is no actual
calyptia/configmap-reload _source_ repository. Turns out, we actually
just retag the package found at [github.com/jimmidyson/configmap-reload](https://github.com/jimmidyson/configmap-reload).
The last time we did this was two years ago, so I just manually did it
this time. I will include steps in the shortcut for future generations.

We already had a more up-to-date version of ingest-check, so a simple
version bump was all we needed here. Tested both locally with a pipeline
that made use of ingest checks and the hot reload deployment strategy.
All containers were able to fetch the new images and start without
issue.